### PR TITLE
Cleanup

### DIFF
--- a/src/http/get-ipr-000user-000repo-pull-000prEtc/package-lock.json
+++ b/src/http/get-ipr-000user-000repo-pull-000prEtc/package-lock.json
@@ -3,9 +3,9 @@
   "lockfileVersion": 1,
   "dependencies": {
     "@architect/functions": {
-      "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/@architect/functions/-/functions-3.12.1.tgz",
-      "integrity": "sha512-oFALFw1zuoPdU2RX+RUx1rrwOMtRVqOVC/8QK8P2+6Ql1/lleOBvtPhxFtbjKGboA0JD3BMInFSJ5Ha+f4qhbQ==",
+      "version": "3.12.2",
+      "resolved": "https://registry.npmjs.org/@architect/functions/-/functions-3.12.2.tgz",
+      "integrity": "sha512-uC7U7SR0owGBKmg/cxk5mGcvNm5dSFkO8xdJrUhDq8KBL7OO9C2Co6S2Y43kJUvCaDg8nlkuWx0nQB/PO4CGSw==",
       "requires": {
         "aws-serverless-express": "^3.3.8",
         "cookie": "^0.4.1",
@@ -119,9 +119,9 @@
       }
     },
     "js-base64": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.2.tgz",
-      "integrity": "sha512-Vg8czh0Q7sFBSUMWWArX/miJeBWYBPpdU/3M/DKSaekLMqrqVPaedp+5mZhie/r0lgrcaYBfwXatEew6gwgiQQ=="
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.3.tgz",
+      "integrity": "sha512-fiUvdfCaAXoQTHdKMgTvg6IkecXDcVz6V5rlftUTclF9IKBjMizvSdQaCl/z/6TApDeby5NL+axYou3i0mu1Pg=="
     },
     "media-typer": {
       "version": "0.3.0",

--- a/src/http/get-ipr-000user-000repo-pull-000prEtc/package.json
+++ b/src/http/get-ipr-000user-000repo-pull-000prEtc/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@architect/functions": "^3.12.1",
+    "@architect/functions": "^3.12.2",
     "@begin/data": "^1.2.3",
     "github-api": "^3.3.0"
   }

--- a/src/http/get-preview-000u-000r-000k-000etc/_validate.js
+++ b/src/http/get-preview-000u-000r-000k-000etc/_validate.js
@@ -11,8 +11,7 @@ module.exports = function validate(req) {
 
 	if (kind === 'sha' && etc.length === 40 && !path.endsWith('/')) {
 		/*
-		 * etc.length 40 == SHA URL request, and we need a trailing trailing slash
-		 * Seems a little hacky but it's only temporary until we implement non-trailing slash index.html peeking into arc/fns
+		 * etc.length 40 == SHA URL request, and we need a trailing trailing slash to ensure asset paths are valid to browsers
 		 */
 		return {
 			location: `${req.path}/`,

--- a/src/http/get-preview-000u-000r-000k-000etc/package-lock.json
+++ b/src/http/get-preview-000u-000r-000k-000etc/package-lock.json
@@ -4,9 +4,9 @@
   "lockfileVersion": 1,
   "dependencies": {
     "@architect/functions": {
-      "version": "3.12.2-RC.0",
-      "resolved": "https://registry.npmjs.org/@architect/functions/-/functions-3.12.2-RC.0.tgz",
-      "integrity": "sha512-Kl4GgV8EhlAMEhxAS6QW7XMJJ3Tw97hGWBaExnhUentFeEq5fk1lciD6MLkJAoiWtJaiDu2PKPVgfZNj+/Qz0g==",
+      "version": "3.12.2",
+      "resolved": "https://registry.npmjs.org/@architect/functions/-/functions-3.12.2.tgz",
+      "integrity": "sha512-uC7U7SR0owGBKmg/cxk5mGcvNm5dSFkO8xdJrUhDq8KBL7OO9C2Co6S2Y43kJUvCaDg8nlkuWx0nQB/PO4CGSw==",
       "requires": {
         "aws-serverless-express": "^3.3.8",
         "cookie": "^0.4.1",

--- a/src/http/get-preview-000u-000r-000k-000etc/package.json
+++ b/src/http/get-preview-000u-000r-000k-000etc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "begin-app-get-preview-000user-000repo-pull-000pr",
   "dependencies": {
-    "@architect/functions": "^3.12.2-RC.0",
+    "@architect/functions": "^3.12.2",
     "@begin/data": "^1.2.3"
   }
 }

--- a/src/http/post-preview-000u-000r/package-lock.json
+++ b/src/http/post-preview-000u-000r/package-lock.json
@@ -3,9 +3,9 @@
   "lockfileVersion": 1,
   "dependencies": {
     "@architect/functions": {
-      "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/@architect/functions/-/functions-3.12.1.tgz",
-      "integrity": "sha512-oFALFw1zuoPdU2RX+RUx1rrwOMtRVqOVC/8QK8P2+6Ql1/lleOBvtPhxFtbjKGboA0JD3BMInFSJ5Ha+f4qhbQ==",
+      "version": "3.12.2",
+      "resolved": "https://registry.npmjs.org/@architect/functions/-/functions-3.12.2.tgz",
+      "integrity": "sha512-uC7U7SR0owGBKmg/cxk5mGcvNm5dSFkO8xdJrUhDq8KBL7OO9C2Co6S2Y43kJUvCaDg8nlkuWx0nQB/PO4CGSw==",
       "requires": {
         "aws-serverless-express": "^3.3.8",
         "cookie": "^0.4.1",

--- a/src/http/post-preview-000u-000r/package.json
+++ b/src/http/post-preview-000u-000r/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@architect/functions": "^3.12.1",
+    "@architect/functions": "^3.12.2",
     "@begin/data": "^1.2.3",
     "mime-types": "^2.1.27",
     "tiny-json-http": "^7.2.0"


### PR DESCRIPTION
Per our conversation (on Slack), despite the name of the branch, I wound up not cleaning up the logic here: https://github.com/ljharb/tc39-ci/blob/master/src/http/get-preview-000u-000r-000k-000etc/_validate.js#L12-L20

Technically Architect Functions now supports loading preview without the trailing slash, but it presents pathing issues. For example:
```
<!DOCTYPE html><html><head><meta charset="utf-8">
<link rel="icon" href="img/favicon.ico">
<link href="ecmarkup.css" rel="stylesheet">
<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
<script src="ecmarkup.js"></script>
```
The trailing slash means the browser loads `ecmarkup.js` (etc.) out of `https://ci.tc39.es/preview/tc39/ecma262/sha/{sha}/ecmarkup.js`

No trailing slash means browser would attempt to load it out of the next path part up, so `https://ci.tc39.es/preview/tc39/ecma262/sha/ecmarkup.js`, which would fail (and should not be valid).